### PR TITLE
Add PWA-based work hours tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # timeR
-a time noting app for worked hours
+
+timeR is a lightweight Progressive Web App for tracking work entries. Record the date, start and finish times, note if lunch was taken and add a description of the tasks completed. Entries are stored in your browser and can be queried over custom ranges or quick presets like last week or last month. Each entry automatically deducts 30 minutes when lunch is marked.
+
+## Usage
+
+Open `index.html` in a modern browser. Add entries via the form and search for totals using a custom range or preset buttons. Install to your device home screen for an app-like experience.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,69 @@
+const entries = JSON.parse(localStorage.getItem('entries') || '[]');
+
+function saveEntries() {
+  localStorage.setItem('entries', JSON.stringify(entries));
+}
+
+function computeHours(entry) {
+  const start = new Date(`${entry.date}T${entry.start}`);
+  const finish = new Date(`${entry.date}T${entry.finish}`);
+  let diff = (finish - start) / 3600000; // hours
+  if (entry.lunch) diff -= 0.5;
+  return diff;
+}
+
+document.getElementById('entry-form').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const entry = {
+    date: document.getElementById('date').value,
+    start: document.getElementById('start').value,
+    finish: document.getElementById('finish').value,
+    lunch: document.getElementById('lunch').checked,
+    description: document.getElementById('description').value,
+  };
+  entries.push(entry);
+  saveEntries();
+  e.target.reset();
+});
+
+function displayEntries(from, to) {
+  const tbody = document.querySelector('#entries-table tbody');
+  tbody.innerHTML = '';
+  let total = 0;
+  entries.forEach((e) => {
+    const entryDate = new Date(e.date);
+    if (entryDate >= from && entryDate <= to) {
+      const hrs = computeHours(e);
+      total += hrs;
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${e.date}</td><td>${e.start}</td><td>${e.finish}</td><td>${e.lunch ? 'Yes' : 'No'}</td><td>${hrs.toFixed(2)}</td><td>${e.description}</td>`;
+      tbody.appendChild(row);
+    }
+  });
+  document.getElementById('total-hours').textContent = total.toFixed(2);
+}
+
+document.getElementById('search-btn').addEventListener('click', () => {
+  const from = new Date(document.getElementById('from-date').value);
+  const to = new Date(document.getElementById('to-date').value);
+  if (!isNaN(from) && !isNaN(to)) {
+    displayEntries(from, to);
+  }
+});
+
+document.querySelectorAll('button[data-range]').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const today = new Date();
+    let from, to;
+    if (btn.dataset.range === 'last-week') {
+      to = new Date(today);
+      from = new Date(today);
+      from.setDate(from.getDate() - 7);
+    } else if (btn.dataset.range === 'last-month') {
+      to = new Date(today);
+      from = new Date(today);
+      from.setMonth(from.getMonth() - 1);
+    }
+    displayEntries(from, to);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>timeR</title>
+  <link rel="manifest" href="manifest.json" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>timeR</h1>
+  <section id="add-entry">
+    <h2>New Entry</h2>
+    <form id="entry-form">
+      <label>Date: <input type="date" id="date" required /></label>
+      <label>Start: <input type="time" id="start" required /></label>
+      <label>Finish: <input type="time" id="finish" required /></label>
+      <label><input type="checkbox" id="lunch" /> Had lunch</label>
+      <label>Description:<br /><textarea id="description"></textarea></label>
+      <button type="submit">Add</button>
+    </form>
+  </section>
+
+  <section id="search">
+    <h2>Search</h2>
+    <label>From: <input type="date" id="from-date" /></label>
+    <label>To: <input type="date" id="to-date" /></label>
+    <button id="search-btn">Search</button>
+    <button data-range="last-week">Last Week</button>
+    <button data-range="last-month">Last Month</button>
+    <div id="results">
+      <p>Total hours: <span id="total-hours">0</span></p>
+      <table id="entries-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Start</th>
+            <th>Finish</th>
+            <th>Lunch</th>
+            <th>Hours</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
+  <script src="app.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "timeR",
+  "short_name": "timeR",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Track work hours",
+  "icons": [
+    {
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8cmVjdCB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgZmlsbD0iIzE5NzZkMiIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkeT0iLjM1ZW0iIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZvbnQtc2l6ZT0iNDAwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZmlsbD0iI2ZmZiI+VDwvdGV4dD4KPC9zdmc+Cg==",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8cmVjdCB3aWR0aD0iNTEyIiBoZWlnaHQ9IjUxMiIgZmlsbD0iIzE5NzZkMiIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBkeT0iLjM1ZW0iIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZvbnQtc2l6ZT0iNDAwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZmlsbD0iI2ZmZiI+VDwvdGV4dD4KPC9zdmc+Cg==",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,20 @@
+const CACHE = 'timer-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/app.js',
+  '/manifest.json'
+];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    caches.open(CACHE).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', (e) => {
+  e.respondWith(
+    caches.match(e.request).then((res) => res || fetch(e.request))
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,19 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 1rem;
+}
+section {
+  margin-bottom: 2rem;
+}
+label {
+  display: block;
+  margin: 0.5rem 0;
+}
+#entries-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+#entries-table th, #entries-table td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+}


### PR DESCRIPTION
## Summary
- build minimal web app to record daily work entries (date, times, lunch flag, description)
- allow querying custom or preset date ranges and compute hours with lunch deduction
- enable PWA support with manifest and service worker caching assets
- replace PNG icons with inline SVG data URIs to avoid binary files

## Testing
- `node --check app.js`
- `node --check service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_689fac52b5048323b56a75c90bbe0558